### PR TITLE
bugfix: cannot set original column name for fvcpm

### DIFF
--- a/src/main/scala/com/github/takemikami/selica/ml/fpm/FrequentViewConversionPatternMining.scala
+++ b/src/main/scala/com/github/takemikami/selica/ml/fpm/FrequentViewConversionPatternMining.scala
@@ -130,7 +130,7 @@ class FrequentViewConversionPatternMining(override val uid: String)
     val consequenceItems = consequenceSupportMap.keySet
 
     // compute confidence
-    val ruleDF = dataset.select("antecedent", "consequent").rdd.map { t =>
+    val ruleDF = dataset.select($(antecedentCol), $(consequentCol)).rdd.map { t =>
       (t(0), t(1)) match {
         case (x: scala.collection.mutable.WrappedArray[Int], y: scala.collection.mutable.WrappedArray[Int]) => {
           val ac = x.map(a => if (antecedentItems.contains(a)) a else 0).filter {

--- a/src/test/scala/com/github/takemikami/selica/ml/fpm/FrequentViewConversionPatternMiningSpec.scala
+++ b/src/test/scala/com/github/takemikami/selica/ml/fpm/FrequentViewConversionPatternMiningSpec.scala
@@ -60,6 +60,24 @@ class FrequentViewConversionPatternMiningSpec extends FlatSpec with BeforeAndAft
 
   }
 
+  "FrequentViewConversionPatternMining" should "can name column originally" in {
+    val spark = sparkSession
+    import spark.implicits._
+
+    val dataset = spark.createDataset(Seq(
+      (1, Array(1,2,3), Array(1)),
+      (1, Array(4,5,6), Array(4,6)),
+      (2, Array(2,3,4), Array(1))
+    )).toDF("userColumn", "antecedentColumn", "consequentColumn")
+
+    val fpm = new com.github.takemikami.selica.ml.fpm.FrequentViewConversionPatternMining()
+      .setAntecedentCol("antecedentColumn")
+      .setConsequentCol("consequentColumn")
+    val model = fpm.fit(dataset)
+
+    val predict = model.transform(dataset)
+  }
+
   "FrequentViewConversionPatternMining" should "can fit with minimal support confidence" in {
     val spark = sparkSession
     import spark.implicits._


### PR DESCRIPTION
## Purpose
_Describe the problem or feature in addition to a link to the issues._
bugfix: cannot set original column name (antecedent, consequence) for fvcpm

## Approach
_How does this change address the problem?_
change fixed column name to given column name.

## Learning
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

